### PR TITLE
Correct typos in Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #################
-# CPU, TPU or GPU. If you enter an incorret option, it will default to CPU-only
+# CPU, TPU or GPU. If you enter an incorrect option, it will default to CPU-only
 ACCELERATOR = TPU
 
 # variables

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ optional arguments:
 
 ```
 
-In particular, if your model parameters ever get corrupted, for example through an interrupted download, you can forceably reset them through the `--force_reload` parameters:
+In particular, if your model parameters ever get corrupted, for example through an interrupted download, you can forcibly reset them through the `--force_reload` parameters:
 
 ```text
-# Run sampling with the AbBFN model and forceably reload the model parameters
+# Run sampling with the AbBFN model and forcibly reload the model parameters
 make sample RUN_ARGS="--model AbBFN --force_reload"
 ```
 


### PR DESCRIPTION
Correct typos in `Makefile` and `README`, found by running [`codespell`](https://github.com/codespell-project/codespell) on the codebase.

```
./Makefile:2: incorret ==> incorrect
./README.md:120: forceably ==> forcibly
./README.md:123: forceably ==> forcibly
```